### PR TITLE
Archive repo: alex feature merged into way_of_working

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # WayOfWorking::InclusiveLanguage::Alex
 
+> [!IMPORTANT]
+> **This repository has been archived.**
+>
+> The Inclusive Language (alex) feature has been merged into the main [`way_of_working`](https://github.com/HealthDataInsight/way_of_working) gem, where it is now a built-in, opt-in feature. Enable it by requiring it:
+>
+> ```ruby
+> require 'way_of_working/inclusive_language/alex'
+> ```
+>
+> Then use `way_of_working init inclusive_language` and `way_of_working exec inclusive_language` as before. This repository is no longer maintained.
+
 <!-- Way of Working: Main Badge Holder Start -->
 ![Way of Working Badge](https://img.shields.io/badge/Way_of_Working-v2.0.1-%238169e3?labelColor=black)
 <!-- Way of Working: Additional Badge Holder Start -->


### PR DESCRIPTION
The Inclusive Language (alex) feature has been merged into the main [`way_of_working`](https://github.com/HealthDataInsight/way_of_working) gem, where it is now a built-in, opt-in feature (`require 'way_of_working/inclusive_language/alex'`).

This PR adds a notice to the top of the README pointing users to the bundled feature and marking this repository as archived / no longer maintained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)